### PR TITLE
Better Internal User Management

### DIFF
--- a/src/subscriptions-client.ts
+++ b/src/subscriptions-client.ts
@@ -5,6 +5,7 @@ import { AlEntitlementCollection } from './types';
 export class AlSubscriptionsClient {
 
   private alClient;
+  private internalUser:boolean = false;
 
   constructor( client:AlApiClient = null ) {
       this.alClient = client || ALClient;
@@ -17,7 +18,7 @@ export class AlSubscriptionsClient {
    */
   async getEntitlements( accountId:string ):Promise<AlEntitlementCollection> {
     const rawEntitlementData = await this.getRawEntitlements( accountId );
-    return AlEntitlementCollection.import( rawEntitlementData );
+    return AlEntitlementCollection.import( rawEntitlementData, this.internalUser );
   }
 
   /**
@@ -168,6 +169,10 @@ export class AlSubscriptionsClient {
       data: subscription,
     });
     return updated;
+  }
+
+  public setInternalUser( internal:boolean ) {
+    this.internalUser = internal;
   }
 }
 

--- a/src/types/al-subscription.types.ts
+++ b/src/types/al-subscription.types.ts
@@ -38,7 +38,7 @@ export class AlEntitlementCollection
     /**
      * Static method to import an AlEntitlementCollection from a raw API response.
      */
-    public static import( rawData:any ):AlEntitlementCollection {
+    public static import( rawData:any, internalUser:boolean = false ):AlEntitlementCollection {
         let records = [];
         if ( rawData.hasOwnProperty( "entitlements" ) ) {
             for ( let i = 0; i < rawData.entitlements.length; i++ ) {
@@ -69,7 +69,7 @@ export class AlEntitlementCollection
                 } );
             }
         }
-        if ( rawData.hasOwnProperty( "account_id" ) && rawData.account_id === '2' ) {
+        if ( rawData.hasOwnProperty( "account_id" ) && rawData.account_id === '2' || internalUser ) {
             //  We need a pseudo entitlement to indicate this user is an internal Alert Logic user.
             records.push( {
                 productId: "al_internal_user",


### PR DESCRIPTION
Allow user to specify whether the acting user qualifies as 'internal' or not (used in UI to expose certain menu options and hide others)